### PR TITLE
Fix Prisma path resolution for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^prisma/(.*)$": "<rootDir>/../prisma/$1",
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/card-sets/card-sets.controller.spec.ts
+++ b/src/card-sets/card-sets.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { CardSetsController } from "./card-sets.controller";
 import { CardSetsService } from "./card-sets.service";
+import { PrismaService } from "prisma/prisma.service";
 
 describe("CardSetsController", () => {
   let controller: CardSetsController;
@@ -8,7 +9,7 @@ describe("CardSetsController", () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CardSetsController],
-      providers: [CardSetsService],
+      providers: [CardSetsService, { provide: PrismaService, useValue: {} }],
     }).compile();
 
     controller = module.get<CardSetsController>(CardSetsController);


### PR DESCRIPTION
## Summary
- configure Jest to resolve `prisma` and `src` path aliases
- mock `PrismaService` in card-sets controller test

## Testing
- `CI=true npm test card-sets/card-sets.controller.spec.ts -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_688fb380c3d483279d0c6e9ce9a934f0