### PR TITLE
fix ownership message in cards service

### DIFF
--- a/src/cards/cards.service.ts
+++ b/src/cards/cards.service.ts
@@ -42,7 +42,7 @@ export class CardsService {
 
     if (!isUserOwnsCardSet) {
       throw new BadRequestException(
-        "You can't update a card set that you does not own"
+        "You can't update a card set that you do not own"
       );
     }
 


### PR DESCRIPTION
## Summary
- correct grammar for card set ownership error

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'prisma/prisma.service', 26 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688fb47b6f1483279a842cf63db2f5af