### PR TITLE
fix: tidy Prisma import in likes service

### DIFF
--- a/src/likes/likes.service.ts
+++ b/src/likes/likes.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable } from "@nestjs/common";
 import { CreateLikeDto } from "./dto/create-like.dto";
 import { UpdateLikeDto } from "./dto/update-like.dto";
 import { Request, Response } from "express";
-import { PrismaService } from "prisma/prisma.service"; // Adjust the import path as necessary
+import { PrismaService } from "prisma/prisma.service";
 
 @Injectable()
 export class LikesService {


### PR DESCRIPTION
## Summary
- remove leftover comment from PrismaService import in likes service

## Testing
- `npm test` *(fails: Cannot find module 'prisma/prisma.service' and other suites fail)*

------
https://chatgpt.com/codex/tasks/task_e_688fb48bb7388327b958f5dba906cabb